### PR TITLE
Reorganize TravisCI build config to fix cross-platform builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,19 +1,26 @@
 language: go
 sudo: false
 
+go:
+  - "1.8.x"
+  - "1.9.x"
+  - "1.10.x"
+  - "1.11.x"
+  - tip
+env:
+  - GIMME_OS=linux
+  - GIMME_OS=darwin
+  - GIMME_OS=windows
+
 matrix:
-  include:
-    - go: 1.8
-    - go: 1.9
+  allow_failures:
     - go: tip
+  fast_finish: true
 
 install:
-  - # Skip
+  - go get -d -v ./...
 
 script:
-  - go get -t -v ./...
   - diff -u <(echo -n) <(gofmt -d .)
   - go tool vet .
-  - GOOS=linux go build -o duckdns-linux
-  - GOOS=darwin go build -o duckdns-macos
-  - GOOS=windows go build -o duckdns-windows
+  - go build -v ./...


### PR DESCRIPTION
The issue in #4 was caused by the platform-specific dependencies of [logrus](/sirupsen/logrus).

This could've been solved by simply adding an extra `go get` for the missing dependency (see sirupsen/logrus#824), but as I was already editing the Travis build config, I reorganized it to delegate more steps to the build matrix and pull the correct dependencies for each platform.

The result should be a bit more future proof builds for the project.

Fixes #3 and fixes #4.